### PR TITLE
Update MailgunSwiftTransport.php

### DIFF
--- a/src/MailgunSwiftTransport.php
+++ b/src/MailgunSwiftTransport.php
@@ -6,7 +6,7 @@ use \Exception;
 use \Swift_MimePart;
 use \Swift_Transport;
 use \Swift_Attachment;
-use \Swift_Mime_Message;
+use \Swift_Mime_SimpleMessage;
 use \Swift_Events_SendEvent;
 use \Swift_Events_EventListener;
 use Psr\Log\LoggerInterface;
@@ -93,12 +93,12 @@ class MailgunSwiftTransport implements Swift_Transport
     }
 
     /**
-     * @param Swift_Mime_Message $message
+     * @param Swift_Mime_SimpleMessage $message
      * @param null $failedRecipients
      * @return int Number of messages sent
      */
     public function send(
-        Swift_Mime_Message $message,
+        Swift_Mime_SimpleMessage $message,
         &$failedRecipients = null
     ) {
         $this->resultApi = null;


### PR DESCRIPTION
Changed Swift_Mime_Message to Swift_Mime_SimpleMessage, as Swift_Mime_Message was no longer available in Swiftmailer version 6 which is now used in SilverStripe since 4.9.0.

The error message you will get is:

Fatal error: Could not check compatibility between LeKoala\Mailgun\MailgunSwiftTransport::send(Swift_Mime_Message $message, &$failedRecipients = NULL) and Swift_Transport::send(Swift_Mime_SimpleMessage $message, &$failedRecipients = NULL), because class Swift_Mime_Message is not available in MailgunSwiftTransport.php on line 100